### PR TITLE
Add type to discriminator func encoder setting

### DIFF
--- a/go1/1.19/1.19.4/encode.go
+++ b/go1/1.19/1.19.4/encode.go
@@ -370,8 +370,6 @@ func isEmptyValue(v reflect.Value) bool {
 	return false
 }
 
-
-
 func (e *encodeState) reflectValue(v reflect.Value, opts encOpts) {
 	valueEncoder(v)(e, v, opts)
 }
@@ -385,6 +383,8 @@ type encOpts struct {
 	discriminatorTypeFieldName string
 	// see Encoder.SetDiscriminator
 	discriminatorValueFieldName string
+	// see Encoder.SetDiscriminator
+	discriminatorValueFn TypeToDiscriminatorFunc
 	// see Encoder.SetDiscriminator
 	discriminatorEncodeMode DiscriminatorEncodeMode
 }

--- a/go1/1.19/1.19.4/stream.go
+++ b/go1/1.19/1.19.4/stream.go
@@ -208,6 +208,7 @@ type Encoder struct {
 	discriminatorTypeFieldName  string
 	discriminatorValueFieldName string
 	discriminatorEncodeMode     DiscriminatorEncodeMode
+	typeToDiscriminatorFn       TypeToDiscriminatorFunc
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -230,6 +231,7 @@ func (enc *Encoder) Encode(v any) error {
 		discriminatorTypeFieldName:  enc.discriminatorTypeFieldName,
 		discriminatorValueFieldName: enc.discriminatorValueFieldName,
 		discriminatorEncodeMode:     enc.discriminatorEncodeMode,
+		discriminatorValueFn:        enc.typeToDiscriminatorFn,
 	})
 	if err != nil {
 		return err
@@ -294,6 +296,21 @@ func (enc *Encoder) SetDiscriminator(typeFieldName, valueFieldName string, mode 
 	enc.discriminatorTypeFieldName = typeFieldName
 	enc.discriminatorValueFieldName = valueFieldName
 	enc.discriminatorEncodeMode = mode
+	enc.typeToDiscriminatorFn = DefaultDiscriminatorFunc
+}
+
+// SetTypeToDiscriminatorFunc allows for customizing the discriminator value for
+// different types. This may be useful if the golang struct names do not match
+// the desired values. One example would be if discriminator values in a
+// protocol require special characters or start with lowercase letter. The
+// TypeToDiscriminatorFunc implementation may return empty string to suppress
+// the rendering of discriminator for specific type(s).
+func (enc *Encoder) SetTypeToDiscriminatorFunc(f TypeToDiscriminatorFunc) {
+	if f == nil {
+		enc.typeToDiscriminatorFn = DefaultDiscriminatorFunc
+		return
+	}
+	enc.typeToDiscriminatorFn = f
 }
 
 // RawMessage is a raw encoded JSON value.

--- a/import-1.19.go
+++ b/import-1.19.go
@@ -16,6 +16,16 @@ import (
 // options.
 type DiscriminatorEncodeMode = json.DiscriminatorEncodeMode
 
+// TypeToDiscriminatorFunc maps go types to discriminator values.
+type TypeToDiscriminatorFunc = json.TypeToDiscriminatorFunc
+
+// FullName uses the go type name prefixed with package name as discriminator
+// value.
+var FullName = json.FullName
+
+// DefaultDiscriminatorFunc uses the go type name a discriminator.
+var DefaultDiscriminatorFunc = json.DefaultDiscriminatorFunc
+
 const (
 	// DiscriminatorEncodeTypeNameIfRequired is the default behavior when
 	// the discriminator is set, and the type name is only encoded if required.
@@ -29,10 +39,6 @@ const (
 	// for all struct and map values. Please note this specifically does not
 	// apply to the root value.
 	DiscriminatorEncodeTypeNameAllObjects = json.DiscriminatorEncodeTypeNameAllObjects
-
-	// DiscriminatorEncodeTypeNameWithPath causes the type name to be encoded
-	// prefixed with the type's full package path.
-	DiscriminatorEncodeTypeNameWithPath = json.DiscriminatorEncodeTypeNameWithPath
 )
 
 // DiscriminatorToTypeFunc is used to get a reflect.Type from its


### PR DESCRIPTION
This change adds encoder option to set a function that determines discriminator value from type. In addition it fixes the values of the constants used in discriminator mode to take 1 and2 instead of 2 and 4.

SetTypeToDiscriminatorFunc allows for customizing the discriminator value for different types. This may be useful if the golang struct names do not match the desired values. One example would be if discriminator values in a protocol require special characters or start with lowercase letter. The TypeToDiscriminatorFunc implementation may return empty string to suppress the rendering of discriminator for specific type(s).